### PR TITLE
Add GitHub Actions workflow for automated builds and releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Build and Release Extension
+
+on:
+  push:
+    branches: [ master ]
+  create:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Bun
+        run: curl -fsSL https://bun.sh/install | bash
+        shell: bash
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build extension
+        run: node utils/build.js
+
+      - name: Create zip
+        run: |
+          cd build
+          zip -r ../nauta-connect-${{ github.ref_name || github.sha }}.zip .
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-build
+          path: nauta-connect-*.zip
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-build
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: nauta-connect-*.zip
+          generate_release_notes: true


### PR DESCRIPTION
Added a GitHub Actions workflow (.github/workflows/release.yml) that automates building the extension and creating releases.

### Workflow Overview:
- **On push to master**: Installs Bun, runs `bun install`, builds with `node utils/build.js`, zips `build/`, and uploads as artifact for download.
- **On tag creation (v*)**: Downloads the zip and creates a GitHub release with it as an asset + auto-generated notes.

### Usage:
- Merge this PR to enable.
- Push to master: Triggers build (check Actions tab).
- For release: `git tag v1.4.2 && git push origin v1.4.2` – creates release with `nauta-connect-v1.4.2.zip`.

This separates the workflow from the Manifest V3 PR (#1). Test by merging and pushing a commit to master.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572426c1-84af-11f0-a94e-3eef481a796b/task/5307e271-595f-4e14-8520-bdb65e0eda1a))